### PR TITLE
fix[cartesian] Absolute k indexation: fix multiple access

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -424,10 +424,6 @@ class CallInliner(ast.NodeTransformer):
             return self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call, *, target_node=None):  # Cyclomatic complexity too high
-        # Filter for absolute indexation method '.at'
-        if self._filter_absolute_K_index_method(node):
-            return self._absolute_K_index_method(node)
-
         call_name = gt_meta.get_qualified_name_from_node(node.func)
 
         if call_name in self.call_stack:

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -340,7 +340,6 @@ class AbsoluteKIndex(Expr):
     """See gtc.common.AbsoluteKIndex"""
 
     k = attribute(of=Any)
-    func_name = "K_at"
 
 
 @attribclass

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -63,7 +63,6 @@ MATH_BUILTINS = {
 
 builtins_and_inline_ignore = {
     "compile_assert",
-    "K_at",
 }
 
 builtins = {
@@ -602,12 +601,6 @@ IJK = (I, J, K)
 """Tuple of axes I, J, K."""
 
 
-def K_at(value: int):
-    """Stub function used to implement absolute
-    K indexing"""
-    raise RuntimeError("`K_at` stub function only, do not call.")
-
-
 def mask_from_axes(axes):
     if isinstance(axes, Axis):
         axes = (axes,)
@@ -662,6 +655,13 @@ class _FieldDescriptor:
     def __str__(self) -> str:
         return (
             f"Field<[{', '.join(str(ax) for ax in self.axes)}], ({self.dtype}, {self.data_dims})>"
+        )
+
+    def at(self, *, K):
+        """Stub function used to implement absolute
+        K indexing"""
+        raise RuntimeError(
+            "`at(K=...)` stub function only, do not call outside of stencil field indexation."
         )
 
 

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -757,7 +757,7 @@ def test_absolute_K_index(backend):
     @gtscript.stencil(backend=backend)
     def test_literal_access(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
         with computation(PARALLEL), interval(...):
-            out_field = in_field[K_at(2)]
+            out_field = in_field.at(K=2)
 
     in_arr[:, :, :] = 1
     in_arr[:, :, 2] = 42.42
@@ -770,7 +770,7 @@ def test_absolute_K_index(backend):
         in_field: Field[np.float64], out_field: Field[np.float64], idx: int
     ) -> None:
         with computation(PARALLEL), interval(...):
-            out_field = in_field[K_at(idx)]
+            out_field = in_field.at(K=idx)
 
     in_arr[:, :, :] = 1
     in_arr[:, :, 3] = 42.42
@@ -783,7 +783,7 @@ def test_absolute_K_index(backend):
         with computation(PARALLEL), interval(...):
             from __externals__ import K4
 
-            out_field = in_field[K_at(K4)]
+            out_field = in_field.at(K=K4)
 
     in_arr[:, :, :] = 1
     in_arr[:, :, 4] = 42.42
@@ -798,7 +798,7 @@ def test_absolute_K_index(backend):
         out_field: Field[np.float64],
     ) -> None:
         with computation(PARALLEL), interval(...):
-            out_field = in_field[K_at(k_field)]
+            out_field = in_field.at(K=k_field)
 
     in_arr[:, :, :] = 1
     k_arr[:, :] = 1

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -1829,19 +1829,19 @@ class TestAbsoluteIndex:
     def test_good_syntax(self):
         def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
             with computation(PARALLEL), interval(...):
-                out_field = in_field[K_at(0)] + in_field[K_at(1)]
+                out_field = in_field.at(K=0) + in_field.at(K=1)
 
         parse_definition(
             definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
         )
 
-    def test_bad_syntax_specifying_I_J_legacy(self):
+    def test_bad_syntax_not_specifying_K(self):
         def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
             with computation(PARALLEL), interval(...):
-                out_field = in_field[0, 0, K_at(0)]
+                out_field = in_field.at(2)
 
         with pytest.raises(
-            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K Index wrong syntax.*"
+            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K index bad syntax.*"
         ):
             parse_definition(
                 definition_func,
@@ -1852,10 +1852,10 @@ class TestAbsoluteIndex:
     def test_bad_syntax_specifying_I_J_axis(self):
         def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
             with computation(PARALLEL), interval(...):
-                out_field = in_field[I + 1, K_at(0)]
+                out_field = in_field.at(I=1, K=0)
 
         with pytest.raises(
-            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K Index wrong syntax.*"
+            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K index bad syntax.*"
         ):
             parse_definition(
                 definition_func,


### PR DESCRIPTION
When a field is going to be access via absolute K indices, we need to turn all access to IndexAccess so we have the pointer in the code to do so.

Add bookkeeping to do that.